### PR TITLE
show esplora too many requests issue

### DIFF
--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -845,6 +845,17 @@ fn mainnet_wlt_receiving_test_asset() {
 }
 
 #[test]
+#[ignore = "fix needed"] // https://github.com/BP-WG/bp-wallet/issues/70
+fn sync_mainnet_wlt() {
+    initialize();
+
+    let mut wlt_1 = get_mainnet_wallet();
+
+    // sometimes this fails with a 'Too many requests' error when using esplora
+    wlt_1.sync();
+}
+
+#[test]
 fn tapret_wlt_receiving_opret() {
     initialize();
 


### PR DESCRIPTION
By enabling the `sync` call in the `_get_wallet` method, on the CI the `mainnet_wlt_receiving_test` test fails (when using esplora as indexer) receiving the following error:
```
thread 'mainnet_wlt_receiving_test_asset' panicked at tests/utils/helpers.rs:584:14:
called `Result::unwrap()` on an `Err` value: [Esplora(Ureq(Status(429, Response[status: 429, status_text: Too Many Requests, url: https://blockstream.info/api/scripthash/282e17a0c0fee5cd2a5fb4296018e43f54a39b21b62761de8f58b1c6c20b7291/txs]))), Esplora(Ureq(Status(429, Response[status: 429, status_text: Too Many Requests, url: https://blockstream.info/api/scripthash/d2353be27321358c3f7f4c5e38ef5f8da95b35f08e62612cf7edab3082172e9c/txs])))]
```
