### PR TITLE
change mime library: tree_magic_mini -> file-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,10 +731,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
+name = "file-format"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "9ffe3a660c3a1b10e96f304a9413d673b2118d62e4520f7ddf4a4faccfe8b9b9"
 
 [[package]]
 name = "flate2"
@@ -1396,16 +1396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.4.0",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1745,7 @@ dependencies = [
  "bp-std",
  "bp-wallet",
  "descriptors",
+ "file-format",
  "once_cell",
  "psbt",
  "rand",
@@ -1771,7 +1762,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "time",
- "tree_magic_mini",
 ]
 
 [[package]]
@@ -2490,20 +2480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree_magic_mini"
-version = "3.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
-dependencies = [
- "fnv",
- "home",
- "memchr",
- "nom",
- "once_cell",
- "petgraph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "RGB tests"
 
 [dependencies]
 bitcoin_hashes = "0.14.0"
+file-format = { version = "0.25.0", features = ["reader"] }
 once_cell = "1.19.0"
 rand = "0.8.5"
 rstest = "0.19.0"
@@ -23,7 +24,6 @@ serde_yaml = "0.9"
 strum = { version = "0.26.2", features = ["derive"] }
 strum_macros = "0.26.2"
 time = "0.3.34"
-tree_magic_mini = "3.1.5"
 
 # RGB-related deps
 ## bp-core

--- a/tests/utils/helpers.rs
+++ b/tests/utils/helpers.rs
@@ -447,8 +447,9 @@ pub fn attachment_from_fpath(fpath: &str) -> Attachment {
     let file_bytes = std::fs::read(fpath).unwrap();
     let file_hash: sha256::Hash = Hash::hash(&file_bytes[..]);
     let digest = file_hash.to_byte_array().into();
-    let mime = tree_magic_mini::from_filepath(fpath.as_ref())
+    let mime = FileFormat::from_file(fpath)
         .unwrap()
+        .media_type()
         .to_string();
     let media_ty: &'static str = Box::leak(mime.clone().into_boxed_str());
     let media_type = MediaType::with(media_ty);

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -42,6 +42,7 @@ pub use bpwallet::{
 };
 pub use descriptors::Wpkh;
 pub use electrum::{Client as ElectrumClient, ElectrumApi, Param};
+pub use file_format::FileFormat;
 pub use ifaces::{
     rgb20, rgb21,
     rgb21::{EmbeddedMedia, TokenData},


### PR DESCRIPTION
using `file-format` instead of `tree_magic_mini` make tests succeed even on machines that don't have mime information installed