### PR TITLE
fix back_and_forth in witness mode

### DIFF
--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -57,9 +57,12 @@ fn back_and_forth(
         }
     };
 
+    let sats_base = 3000;
+    let mut sats_send = sats_base * loops as u64;
     let now = Instant::now();
     for i in 1..=loops {
         println!("loop {i}/{loops}");
+        sats_send -= DEFAULT_FEE_ABS * 2;
         let wlt_1_send_start = Instant::now();
         wlt_1.send(
             &mut wlt_2,
@@ -67,10 +70,11 @@ fn back_and_forth(
             contract_id,
             &iface_type_name,
             issued_supply - i as u64,
-            1000,
+            sats_send,
             Some(&report),
         );
         let wlt_1_send_duration = wlt_1_send_start.elapsed();
+        sats_send -= DEFAULT_FEE_ABS * 2;
         let wlt_2_send_start = Instant::now();
         wlt_2.send(
             &mut wlt_1,
@@ -78,7 +82,7 @@ fn back_and_forth(
             contract_id,
             &iface_type_name,
             issued_supply - i as u64 - 1,
-            1000,
+            sats_send,
             Some(&report),
         );
         let wlt_2_send_duration = wlt_2_send_start.elapsed();

--- a/tests/utils/helpers.rs
+++ b/tests/utils/helpers.rs
@@ -809,7 +809,7 @@ impl TestWallet {
     ) -> (Transfer, Tx) {
         self.sync();
 
-        let fee = Sats::from_sats(fee.unwrap_or(400));
+        let fee = Sats::from_sats(fee.unwrap_or(DEFAULT_FEE_ABS));
         let sats = Sats::from_sats(sats.unwrap_or(2000));
         let params = TransferParams::with(fee, sats);
         let pay_start = Instant::now();
@@ -1164,7 +1164,7 @@ impl TestWallet {
         beneficiaries: Vec<(Address, Option<u64>)>,
         fee: Option<u64>,
     ) -> (Psbt, PsbtMeta) {
-        let tx_params = TxParams::with(Sats::from_sats(fee.unwrap_or(400)));
+        let tx_params = TxParams::with(Sats::from_sats(fee.unwrap_or(DEFAULT_FEE_ABS)));
         let beneficiaries = self._construct_beneficiaries(beneficiaries);
         let beneficiaries: Vec<&PsbtBeneficiary> = beneficiaries.iter().collect();
 
@@ -1177,7 +1177,7 @@ impl TestWallet {
         beneficiaries: Vec<(Address, Option<u64>)>,
         fee: Option<u64>,
     ) -> (Psbt, PsbtMeta) {
-        let tx_params = TxParams::with(Sats::from_sats(fee.unwrap_or(400)));
+        let tx_params = TxParams::with(Sats::from_sats(fee.unwrap_or(DEFAULT_FEE_ABS)));
         let beneficiaries = self._construct_beneficiaries(beneficiaries);
         let beneficiaries: Vec<&PsbtBeneficiary> = beneficiaries.iter().collect();
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -11,6 +11,7 @@ pub const ESPLORA_REGTEST_URL: &str = "http://127.0.0.1:8094/regtest/api";
 pub const ESPLORA_MAINNET_URL: &str = "https://blockstream.info/api";
 pub const FAKE_TXID: &str = "e5a3e577309df31bd606f48049049d2e1e02b048206ba232944fcc053a176ccb:0";
 pub const UDA_FIXED_INDEX: u32 = 0;
+pub const DEFAULT_FEE_ABS: u64 = 400;
 
 pub use std::{
     cell::OnceCell,


### PR DESCRIPTION
Since there is not yet a smart input selection when using the `pay` method, if we run the `back_and_forth` test in witness mode we encounter the following error
```
called `Result::unwrap()` on an `Err` value: Composition(Construction(NoFundsForFee { input_value: Sats(1000), output_value: Sats(1000), fee: Sats(400) }))
```
this error has already been reported in https://github.com/RGB-WG/rgb/issues/113

For now this PR changes the sat amounts at each loop in a way that both wallets always have enough sats to pay for fees (to avoid `NoFundsForFee`) and have a change output (to avoid `NoBlankOrChange`).

