### PR TITLE
tapret_wlt_receiving_opret 100 times

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,61 +10,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
+  test_tapret_wlt_receiving_opret:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: clippy
-      - name: Lint
-        run: cargo clippy --all-targets -- -D warnings
-
-  format:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
-      - name: Format
-        run: cargo fmt --all -- --check
-
-  test_and_coverage:
-    runs-on: ubuntu-latest
-
+    timeout-minutes: 100
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: true
-
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: llvm-tools-preview
-          toolchain: stable
-
-      - name: Install llvm-cov
-        env:
-          LLVM_COV_RELEASES: https://github.com/taiki-e/cargo-llvm-cov/releases
+      - name: Run tapret_wlt_receiving_opret test 100 times
         run: |
-          host=$(rustc -Vv | grep host | sed 's/host: //')
-          curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
-
-      - name: Test and generate coverage report
-        run: |
-          INDEXER=esplora cargo llvm-cov --output-path coverage.lcov
-          INDEXER=electrum cargo llvm-cov --no-clean --output-path coverage.lcov
-
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          file: coverage.lcov
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
+          cargo test --test transfers tapret_wlt_receiving_opret
+          for i in $(seq 1 100); do echo "run $i"; SKIP_INIT=1 cargo test --test transfers tapret_wlt_receiving_opret || break; done

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -736,7 +736,6 @@ fn mainnet_wlt_receiving_test_asset() {
 }
 
 #[test]
-#[ignore = "this was working, fix needed"]
 fn tapret_wlt_receiving_opret() {
     initialize();
 
@@ -773,6 +772,28 @@ fn tapret_wlt_receiving_opret() {
         contract_id,
         &iface_type_name,
         300,
+        1000,
+        None,
+    );
+
+    println!("4th transfer");
+    wlt_2.send(
+        &mut wlt_1,
+        TransferType::Blinded,
+        contract_id,
+        &iface_type_name,
+        560,
+        1000,
+        None,
+    );
+
+    println!("5th transfer");
+    wlt_1.send(
+        &mut wlt_2,
+        TransferType::Blinded,
+        contract_id,
+        &iface_type_name,
+        600,
         1000,
         None,
     );

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -745,7 +745,7 @@ fn tapret_wlt_receiving_opret() {
     let (contract_id, iface_type_name) = wlt_1.issue_nia(600, wlt_1.close_method(), None);
 
     println!("1st transfer");
-    wlt_1.send(
+    let (consignment, _) = wlt_1.send(
         &mut wlt_2,
         TransferType::Blinded,
         contract_id,
@@ -754,6 +754,8 @@ fn tapret_wlt_receiving_opret() {
         5000,
         None,
     );
+    assert_eq!(consignment.bundles.len(), 1);
+    assert_eq!(consignment.terminals.len(), 1);
 
     println!("2nd transfer");
     let invoice = wlt_1.invoice(
@@ -763,10 +765,12 @@ fn tapret_wlt_receiving_opret() {
         CloseMethod::OpretFirst,
         InvoiceType::Witness,
     );
-    wlt_2.send_to_invoice(&mut wlt_1, invoice, None, None, None);
+    let (consignment, _) = wlt_2.send_to_invoice(&mut wlt_1, invoice, None, None, None);
+    assert_eq!(consignment.bundles.len(), 2);
+    assert_eq!(consignment.terminals.len(), 0);
 
     println!("3rd transfer");
-    wlt_1.send(
+    let (consignment, _) = wlt_1.send(
         &mut wlt_2,
         TransferType::Blinded,
         contract_id,
@@ -775,7 +779,10 @@ fn tapret_wlt_receiving_opret() {
         1000,
         None,
     );
+    assert_eq!(consignment.bundles.len(), 0);
+    assert_eq!(consignment.terminals.len(), 0);
 
+    /*
     println!("4th transfer");
     wlt_2.send(
         &mut wlt_1,
@@ -797,4 +804,5 @@ fn tapret_wlt_receiving_opret() {
         1000,
         None,
     );
+    */
 }


### PR DESCRIPTION
This PR adds on top of #6:
- the checkout of rgb-std to branch `fix/271` (of PR https://github.com/RGB-WG/rgb-std/pull/272)
- the assertions on the consignment bundles and terminals
- a CI job to run the `tapret_wlt_receiving_opret` test 100 times

This is not meant to be merged, it's just here to push ahead the discussion in #6