### PR TITLE
codecov: disable default path fixing

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+codecov:
+  disable_default_path_fixes: true
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,5 @@ coverage:
   status:
     project:
       default:
-        target: 100%
-        threshold: 3%
+        target: 35%
+        threshold: 0%


### PR DESCRIPTION
This is an attempt of fixing the codecov report for this repo, which is not working probably due to usage of submodules, as suggested in https://github.com/codecov/feedback/issues/235