### PR TITLE
add receive_from_unbroadcasted_transfer_to_blinded test

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -74,7 +74,10 @@ pub use rgb::{
     RgbWallet, TapretKey, TransferParams, Transition, WalletProvider, XOutpoint, XWitnessId,
 };
 pub use rgbstd::{
-    containers::{BuilderSeal, ConsignmentExt, Fascia, FileContent, Kit, Transfer, ValidKit},
+    containers::{
+        BuilderSeal, ConsignmentExt, Fascia, FileContent, IndexedConsignment, Kit, Transfer,
+        ValidKit,
+    },
     interface::{
         ContractBuilder, ContractIface, DataAllocation, FilterExclude, FungibleAllocation, Iface,
         IfaceClass, IfaceId, IfaceImpl, NamedField,


### PR DESCRIPTION
The test added in this PR shows what I consider a bug:
a wallet could (maliciously) accept a transfer sending to a blinded UTXO even if the transfer TX has not been broadcasted and then send the assets to another wallet (in the test, `wlt_3`) which will think the received allocation is valid and owned. The receiver will notice this allocation is not spendable only when it actually tries to spend it. I think the wallet should be able to differentiate an allocation coming from a history containing an unbroadcasted/unmined TX.

Run `cargo test --test transfers receive_from_unbroadcasted_transfer_to_blinded -- --nocapture` to see the issue.

To be merged once we have a fix for this.