### PR TITLE
tests retrying an aborted transfer

### DIFF
--- a/tests/utils/helpers.rs
+++ b/tests/utils/helpers.rs
@@ -916,7 +916,9 @@ impl TestWallet {
     }
 
     pub fn accept_transfer(&mut self, consignment: Transfer, report: Option<&Report>) {
-        self.accept_transfer_custom_resolver(consignment, report, &self.get_resolver());
+        let mut resolver = self.get_resolver();
+        resolver.add_terminals(&consignment);
+        self.accept_transfer_custom_resolver(consignment, report, &resolver);
     }
 
     pub fn accept_transfer_custom_resolver(


### PR DESCRIPTION
This PR splits the `same_transfer_twice` test in 3 tests:
- `rbf_transfer`: this is the same test as before, it has just been renamed with a more precise name
- `same_transfer_twice_no_update_witnesses`: this test shows 2 bugs
- `same_transfer_twice_update_witnesses`: this test shows 1 bug

P.S. Since the bugs appear only on branches ready for beta 9 this PR contains also a WIP commit that updates the tests in order to use the updated branches. I suggest looking only at the last commit to understand the reported bugs