### PR TITLE
add sync in revert_genesis to show unhandled reorg

### DIFF
--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -1777,6 +1777,7 @@ fn reorg_history(#[case] history_type: HistoryType, #[case] reorg_type: ReorgTyp
 #[rstest]
 #[ignore = "fix needed"]
 #[case(false)]
+#[ignore = "fix needed"]
 #[case(true)]
 #[serial]
 fn revert_genesis(#[case] with_transfers: bool) {
@@ -1828,6 +1829,11 @@ fn revert_genesis(#[case] with_transfers: bool) {
     ));
     wlt.switch_to_instance(INSTANCE_3);
     assert_eq!(wlt.get_witness_ord(&utxo.txid), WitnessOrd::Archived);
+
+    // this should remove the utxo that is now archived but it doesn't
+    wlt.sync();
+    let utxos = wlt.utxos();
+    assert!(utxos.is_empty());
 
     wlt.check_allocations(
         contract_id,

--- a/tests/utils/helpers.rs
+++ b/tests/utils/helpers.rs
@@ -1103,6 +1103,10 @@ impl TestWallet {
         self.wallet.stock().contracts().unwrap().collect()
     }
 
+    pub fn utxos(&self) -> Vec<WalletUtxo> {
+        self.wallet.wallet().utxos().collect()
+    }
+
     pub fn debug_contracts(&self) {
         println!("Contracts:");
         for info in self.list_contracts() {

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -54,7 +54,7 @@ pub use bpstd::{
 };
 pub use bpwallet::{
     fs::FsTextStore, indexers::esplora::Client as EsploraClient, AnyIndexer, Indexer as BpIndexer,
-    Wallet,
+    Wallet, WalletUtxo,
 };
 pub use descriptors::Wpkh;
 pub use electrum::{Client as ElectrumClient, ElectrumApi, Param};


### PR DESCRIPTION
It seems that bp-wallet doesn't handle bitcoin reorgs. Having a look at the code it seems that transactions and utxos are never removed from the cache, even if they disappear from the blockchain.

Run `cargo test --test transfers revert_genesis::case_1 -- --include-ignored` to see the issue.

@dr-orlovsky could you please provide a fix for this?